### PR TITLE
Add image components

### DIFF
--- a/src/Avatar/Avatar.Styled.js
+++ b/src/Avatar/Avatar.Styled.js
@@ -1,0 +1,44 @@
+import styled, { css } from 'styled-components';
+
+const sizes = {
+  small: { width: '3.4rem', height: '3.4rem' },
+  medium: { width: '4.4rem', height: '4.4rem' },
+  large: { width: '5.4rem', height: '5.4rem' },
+};
+
+const avatarStyles = css`
+  align-items: center;
+  ${({ type }) => `
+    width: ${sizes[type]?.width};
+    height: ${sizes[type]?.height};
+  `}
+`;
+
+export const StyledAvatarComponent = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  justify-content: center;
+
+  ${({ variant }) => css`
+    align-items: ${variant === 'square'
+        ? 'center; flex-wrap: wrap;'
+        : 'center;'}
+      img {
+      border-radius: ${variant === 'square' ? '0.5rem' : '50%'};
+      display: block;
+      overflow: hidden;
+      margin: 0 5px;
+      ${avatarStyles}
+    }
+  `}
+`;
+
+export const AvatarContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  justify-content: center;
+`;
+
+export default StyledAvatarComponent;

--- a/src/Avatar/Avatar.Styled.js
+++ b/src/Avatar/Avatar.Styled.js
@@ -1,13 +1,12 @@
 import styled, { css } from 'styled-components';
 
 const sizes = {
-  small: { width: '3.4rem', height: '3.4rem' },
-  medium: { width: '4.4rem', height: '4.4rem' },
-  large: { width: '5.4rem', height: '5.4rem' },
+  small: { width: '34px', height: '34px' },
+  medium: { width: '44px', height: '44px' },
+  large: { width: '54px', height: '54px' },
 };
 
 const avatarStyles = css`
-  align-items: center;
   ${({ type }) => `
     width: ${sizes[type]?.width};
     height: ${sizes[type]?.height};
@@ -15,16 +14,8 @@ const avatarStyles = css`
 `;
 
 export const StyledAvatarComponent = styled.div`
-  display: flex;
-  flex-direction: row;
-  gap: 1rem;
-  justify-content: center;
-
   ${({ variant }) => css`
-    align-items: ${variant === 'square'
-        ? 'center; flex-wrap: wrap;'
-        : 'center;'}
-      img {
+    img {
       border-radius: ${variant === 'square' ? '0.5rem' : '50%'};
       display: block;
       overflow: hidden;
@@ -39,6 +30,7 @@ export const AvatarContainer = styled.div`
   flex-direction: row;
   gap: 1rem;
   justify-content: center;
+  align-items: center;
 `;
 
 export default StyledAvatarComponent;

--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { StyledAvatarComponent } from './Avatar.Styled';
+
+const Avatar = ({ type, img, variant }) => {
+  return (
+    <StyledAvatarComponent type={type} variant={variant}>
+      <img src={img} alt="Avatar" />
+    </StyledAvatarComponent>
+  );
+};
+
+export default Avatar;

--- a/src/Avatar/Avatar.stories.js
+++ b/src/Avatar/Avatar.stories.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import Avatar from './Avatar';
+import { AvatarContainer } from './Avatar.Styled';
+
+export default {
+  title: 'Avatar',
+  component: Avatar,
+};
+
+export const CircularAvatar = () => (
+  <div>
+    <AvatarContainer>
+      <Avatar type="small" img="https://i.pravatar.cc/40" variant="circle" />
+      <Avatar type="medium" img="https://i.pravatar.cc/41" variant="circle" />
+      <Avatar type="large" img="https://i.pravatar.cc/42" variant="circle" />
+    </AvatarContainer>
+  </div>
+);
+
+export const SquareAvatar = () => (
+  <div>
+    <AvatarContainer>
+      <Avatar type="small" img="https://i.pravatar.cc/45" variant="square" />
+      <Avatar type="medium" img="https://i.pravatar.cc/44" variant="square" />
+      <Avatar type="large" img="https://i.pravatar.cc/43" variant="square" />
+    </AvatarContainer>
+  </div>
+);

--- a/src/Images/Images.Styled.js
+++ b/src/Images/Images.Styled.js
@@ -1,0 +1,61 @@
+import styled, { css } from 'styled-components';
+
+const sizes = {
+  circle: { widths: '150px', heights: '150px' },
+  square: { widths: '150px', heights: '150px' },
+  response: { widths: '100%', heights: '100%' },
+};
+
+export const StyledImagesComponent = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  justify-content: center;
+  align-items: center;
+  height: auto;
+
+  img {
+    margin: auto;
+    ${({ type }) =>
+      type &&
+      css`
+        width: ${sizes[type].widths || 'auto'};
+        height: ${sizes[type].heights || 'auto'};
+      `};
+
+    ${({ type }) =>
+      type === 'square' &&
+      css`
+        object-fit: cover;
+        overflow-clip-margin: content-box;
+        overflow-x: clip;
+        overflow-y: clip;
+      `};
+
+    ${({ type }) =>
+      type === 'circle' &&
+      css`
+        border-radius: 50%;
+        overflow: hidden;
+        margin: 0 5px;
+      `};
+
+    ${({ type }) =>
+      type === 'response' &&
+      css`
+        object-fit: cover;
+        width: 100%;
+        height: auto;
+
+        @media (min-width: 769px) {
+          width: 800px;
+          height: 480px;
+        }
+
+        padding: 10px;
+        margin: 10px;
+      `};
+  }
+`;
+
+export default StyledImagesComponent;

--- a/src/Images/Images.js
+++ b/src/Images/Images.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { StyledImagesComponent } from './Images.Styled';
+
+const Images = ({ type, img }) => {
+  return (
+    <StyledImagesComponent type={type}>
+      <img src={img} alt="Images" />
+    </StyledImagesComponent>
+  );
+};
+
+export default Images;

--- a/src/Images/Images.stories.js
+++ b/src/Images/Images.stories.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { AvatarContainer } from '../Avatar/Avatar.Styled';
+import Images from './Images';
+
+export default {
+  title: 'Images',
+  component: Images,
+};
+
+export const CircularImages = () => (
+  <div>
+    <AvatarContainer>
+      <Images type="circle" img="https://i.pravatar.cc/40" />
+      <Images type="circle" img="https://i.pravatar.cc/41" />
+    </AvatarContainer>
+  </div>
+);
+
+export const SquareImages = () => (
+  <div>
+    <AvatarContainer>
+      <Images type="square" img="https://i.pravatar.cc/45" />
+      <Images type="square" img="https://i.pravatar.cc/44" />
+    </AvatarContainer>
+  </div>
+);
+
+export const ResponsiveImages = () => (
+  <div>
+    <AvatarContainer>
+      <Images type="response" img="https://i.pravatar.cc/" />
+    </AvatarContainer>
+  </div>
+);


### PR DESCRIPTION
Add 3 different types of images

1)Square Images
<img width="1047" alt="Screenshot 2023-12-26 at 10 48 20 AM" src="https://github.com/aeshapatel025/Strive_UI/assets/152843736/f6e4dd0a-8b51-4d92-b5e4-c2d7f34b527e">

2)Circle Images
<img width="1156" alt="Screenshot 2023-12-26 at 10 48 11 AM" src="https://github.com/aeshapatel025/Strive_UI/assets/152843736/5ea0a8da-8b0a-452c-880d-00b99bc447a5">

3) Responsive Images
<img width="1269" alt="Screenshot 2023-12-26 at 10 48 42 AM" src="https://github.com/aeshapatel025/Strive_UI/assets/152843736/19dfc0b6-1298-4931-99a8-f247ed567a0c">

- [x] Checking the code is duplicate or not?
- [x]  Is these code has bug
- [ ]  Is code is check by shubhum sir or ankit sir?
- [ ]  Are you going to merge this or not?