### PR TITLE
Add image components

### DIFF
--- a/src/Badges/Badges.Styled.js
+++ b/src/Badges/Badges.Styled.js
@@ -1,0 +1,90 @@
+import styled, { css } from 'styled-components';
+import theme from '../theme';
+
+const sizes = {
+  small: { width: '34px', height: '34px' },
+  medium: { width: '44px', height: '44px' },
+  large: { width: '54px', height: '54px' },
+};
+
+export const StyledBadgesComponent = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  font-size: 0.6rem;
+  font-weight: bold;
+  font-family: Rubik, sans-serif;
+
+  ${({ variant, colorsEffect }) =>
+    variant === 'image'
+      ? css`
+          position: relative;
+          margin-right: 5px;
+
+          span.badge-number {
+            position: absolute;
+            top: 30px;
+            height: 10px;
+            width: 10px;
+            background-color: ${theme?.[colorsEffect]};
+            color: ${theme?.[colorsEffect]};
+            border-radius: 50%;
+            padding: 2px;
+            transition:
+              top 0.3s ease,
+              font-size 0.3s ease;
+          }
+
+          img {
+            border-radius: 50%;
+            ${({ type }) => `
+              width: ${sizes[type]?.width};
+              height: ${sizes[type]?.height};
+            `}
+          }
+
+          ${colorsEffect &&
+          css`
+            span.badge-number {
+              top: ${colorsEffect === 'primary'
+                ? 17
+                : colorsEffect === 'warning'
+                  ? 26
+                  : 36}px;
+            }
+          `}
+        `
+      : css`
+          position: relative;
+          display: flex;
+          align-items: center;
+          margin-right: 5px;
+
+          span.badge-number {
+            position: absolute;
+            top: 1px;
+            right: -3px;
+            height: 12px;
+            width: 12px;
+            background-color: ${theme.primary};
+            color: ${theme.textColor};
+            border-radius: 50%;
+            padding: 2px;
+            border: 2px solid white;
+          }
+
+          img {
+            border-radius: 50%;
+            transition:
+              width 0.3s ease,
+              height 0.3s ease;
+            ${({ type }) => `
+              width: ${sizes[type]?.width};
+              height: ${sizes[type]?.height};
+            `}
+          }
+        `}
+`;
+
+export default StyledBadgesComponent;

--- a/src/Badges/Badges.Styled.js
+++ b/src/Badges/Badges.Styled.js
@@ -16,8 +16,8 @@ export const StyledBadgesComponent = styled.div`
   font-weight: bold;
   font-family: Rubik, sans-serif;
 
-  ${({ variant, colorsEffect }) =>
-    variant === 'image'
+  ${({ shape, color }) =>
+    shape === 'image'
       ? css`
           position: relative;
           margin-right: 5px;
@@ -27,31 +27,29 @@ export const StyledBadgesComponent = styled.div`
             top: 30px;
             height: 10px;
             width: 10px;
-            background-color: ${theme?.[colorsEffect]};
-            color: ${theme?.[colorsEffect]};
+            background-color: ${theme?.[color]};
+            color: ${theme?.[color]};
             border-radius: 50%;
             padding: 2px;
-            transition:
-              top 0.3s ease,
-              font-size 0.3s ease;
+            transition: top 0.3s ease, font-size 0.3s ease;
           }
 
           img {
             border-radius: 50%;
-            ${({ type }) => `
-              width: ${sizes[type]?.width};
-              height: ${sizes[type]?.height};
+            ${({ size }) => `
+              width: ${sizes[size]?.width};
+              height: ${sizes[size]?.height};
             `}
           }
 
-          ${colorsEffect &&
+          ${color &&
           css`
             span.badge-number {
-              top: ${colorsEffect === 'primary'
+              top: ${color === 'primary'
                 ? 17
-                : colorsEffect === 'warning'
-                  ? 26
-                  : 36}px;
+                : color === 'warning'
+                ? 26
+                : 36}px;
             }
           `}
         `
@@ -76,15 +74,11 @@ export const StyledBadgesComponent = styled.div`
 
           img {
             border-radius: 50%;
-            transition:
-              width 0.3s ease,
-              height 0.3s ease;
-            ${({ type }) => `
-              width: ${sizes[type]?.width};
-              height: ${sizes[type]?.height};
+            transition: width 0.3s ease, height 0.3s ease;
+            ${({ size }) => `
+              width: ${sizes[size]?.width};
+              height: ${sizes[size]?.height};
             `}
           }
         `}
 `;
-
-export default StyledBadgesComponent;

--- a/src/Badges/Badges.Styled.js
+++ b/src/Badges/Badges.Styled.js
@@ -9,76 +9,46 @@ const sizes = {
 
 export const StyledBadgesComponent = styled.div`
   display: flex;
-  flex-direction: row;
   justify-content: center;
   align-items: center;
   font-size: 0.6rem;
   font-weight: bold;
   font-family: Rubik, sans-serif;
+  position: relative;
+  margin: 0 5px 0 0;
 
-  ${({ shape, color }) =>
-    shape === 'image'
+  span.badge-number {
+    position: absolute;
+    height: 12px;
+    width: 12px;
+    border-radius: 50%;
+    padding: 2px;
+  }
+
+  img {
+    border-radius: 50%;
+    ${({ size }) => `
+      width: ${sizes[size]?.width};
+      height: ${sizes[size]?.height};
+    `}
+  }
+
+  ${({ type, color }) =>
+    type === 'default'
       ? css`
-          position: relative;
-          margin-right: 5px;
-
           span.badge-number {
-            position: absolute;
-            top: 30px;
-            height: 10px;
-            width: 10px;
             background-color: ${theme?.[color]};
             color: ${theme?.[color]};
-            border-radius: 50%;
-            padding: 2px;
-            transition: top 0.3s ease, font-size 0.3s ease;
+            top: ${color === 'primary' ? 17 : color === 'warning' ? 26 : 36}px;
           }
-
-          img {
-            border-radius: 50%;
-            ${({ size }) => `
-              width: ${sizes[size]?.width};
-              height: ${sizes[size]?.height};
-            `}
-          }
-
-          ${color &&
-          css`
-            span.badge-number {
-              top: ${color === 'primary'
-                ? 17
-                : color === 'warning'
-                ? 26
-                : 36}px;
-            }
-          `}
         `
       : css`
-          position: relative;
-          display: flex;
-          align-items: center;
-          margin-right: 5px;
-
           span.badge-number {
-            position: absolute;
             top: 1px;
             right: -3px;
-            height: 12px;
-            width: 12px;
             background-color: ${theme.primary};
             color: ${theme.textColor};
-            border-radius: 50%;
-            padding: 2px;
-            border: 2px solid white;
-          }
-
-          img {
-            border-radius: 50%;
-            transition: width 0.3s ease, height 0.3s ease;
-            ${({ size }) => `
-              width: ${sizes[size]?.width};
-              height: ${sizes[size]?.height};
-            `}
+            border: 2px solid ${theme.textColor};
           }
         `}
 `;

--- a/src/Badges/Badges.js
+++ b/src/Badges/Badges.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { StyledBadgesComponent } from './Badges.Styled';
+
+const Badges = ({ type, variant, img, number, colorsEffect }) => {
+  return (
+    <StyledBadgesComponent
+      type={type}
+      number={number}
+      colorsEffect={colorsEffect}
+      variant={variant}
+    >
+      <div className="badge-content">
+        <span className="badge-number">{number}</span>
+        <img src={img} alt="badge" />
+      </div>
+    </StyledBadgesComponent>
+  );
+};
+
+export default Badges;

--- a/src/Badges/Badges.js
+++ b/src/Badges/Badges.js
@@ -1,16 +1,17 @@
 import React from 'react';
 import { StyledBadgesComponent } from './Badges.Styled';
+import { count } from 'console';
 
-const Badges = ({ type, variant, img, number, colorsEffect }) => {
+const Badges = ({ count, shape, img, count, color }) => {
   return (
     <StyledBadgesComponent
-      type={type}
-      number={number}
-      colorsEffect={colorsEffect}
-      variant={variant}
+      shape={shape}
+      count={count}
+      color={color}
+      size={size}
     >
       <div className="badge-content">
-        <span className="badge-number">{number}</span>
+        <span className="badge-number">{count}</span>
         <img src={img} alt="badge" />
       </div>
     </StyledBadgesComponent>

--- a/src/Badges/Badges.js
+++ b/src/Badges/Badges.js
@@ -1,15 +1,9 @@
 import React from 'react';
 import { StyledBadgesComponent } from './Badges.Styled';
-import { count } from 'console';
 
-const Badges = ({ count, shape, img, count, color }) => {
+const Badges = ({ count, type, img, size, color }) => {
   return (
-    <StyledBadgesComponent
-      shape={shape}
-      count={count}
-      color={color}
-      size={size}
-    >
+    <StyledBadgesComponent type={type} count={count} color={color} size={size}>
       <div className="badge-content">
         <span className="badge-number">{count}</span>
         <img src={img} alt="badge" />

--- a/src/Badges/Badges.stories.js
+++ b/src/Badges/Badges.stories.js
@@ -12,19 +12,19 @@ export const CartBadges = () => (
     <StyledBadgesComponent>
       <Badges
         size="small"
-        shape="cart"
+        type="cart"
         img="https://adorn-components.netlify.app/assets/images/cart.svg"
         count={10}
       />
       <Badges
         size="medium"
-        shape="cart"
+        type="cart"
         img="https://adorn-components.netlify.app/assets/images/cart.svg"
         count={12}
       />
       <Badges
         size="large"
-        shape="cart"
+        type="cart"
         img="https://adorn-components.netlify.app/assets/images/cart.svg"
         count={15}
       />
@@ -37,19 +37,19 @@ export const ImageBadges = () => (
     <StyledBadgesComponent>
       <Badges
         size="small"
-        shape="image"
+        type="default"
         color="primary"
         img="https://i.pravatar.cc/62"
       />
       <Badges
         size="medium"
-        shape="image"
+        type="default"
         color="warning"
         img="https://i.pravatar.cc/61"
       />
       <Badges
         size="large"
-        shape="image"
+        type="default"
         color="success"
         img="https://i.pravatar.cc/60"
       />

--- a/src/Badges/Badges.stories.js
+++ b/src/Badges/Badges.stories.js
@@ -11,22 +11,22 @@ export const CartBadges = () => (
   <div>
     <StyledBadgesComponent>
       <Badges
-        type="small"
-        variant="cart"
+        size="small"
+        shape="cart"
         img="https://adorn-components.netlify.app/assets/images/cart.svg"
-        number={10}
+        count={10}
       />
       <Badges
-        type="medium"
-        variant="cart"
+        size="medium"
+        shape="cart"
         img="https://adorn-components.netlify.app/assets/images/cart.svg"
-        number={12}
+        count={12}
       />
       <Badges
-        type="large"
-        variant="cart"
+        size="large"
+        shape="cart"
         img="https://adorn-components.netlify.app/assets/images/cart.svg"
-        number={15}
+        count={15}
       />
     </StyledBadgesComponent>
   </div>
@@ -36,21 +36,21 @@ export const ImageBadges = () => (
   <div>
     <StyledBadgesComponent>
       <Badges
-        type="small"
-        variant="image"
-        colorsEffect="primary"
+        size="small"
+        shape="image"
+        color="primary"
         img="https://i.pravatar.cc/62"
       />
       <Badges
-        type="medium"
-        variant="image"
-        colorsEffect="warning"
+        size="medium"
+        shape="image"
+        color="warning"
         img="https://i.pravatar.cc/61"
       />
       <Badges
-        type="large"
-        variant="image"
-        colorsEffect="success"
+        size="large"
+        shape="image"
+        color="success"
         img="https://i.pravatar.cc/60"
       />
     </StyledBadgesComponent>

--- a/src/Badges/Badges.stories.js
+++ b/src/Badges/Badges.stories.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import Badges from './Badges';
+import { StyledBadgesComponent } from './Badges.Styled';
+
+export default {
+  title: 'Badges',
+  component: Badges,
+};
+
+export const CartBadges = () => (
+  <div>
+    <StyledBadgesComponent>
+      <Badges
+        type="small"
+        variant="cart"
+        img="https://adorn-components.netlify.app/assets/images/cart.svg"
+        number={10}
+      />
+      <Badges
+        type="medium"
+        variant="cart"
+        img="https://adorn-components.netlify.app/assets/images/cart.svg"
+        number={12}
+      />
+      <Badges
+        type="large"
+        variant="cart"
+        img="https://adorn-components.netlify.app/assets/images/cart.svg"
+        number={15}
+      />
+    </StyledBadgesComponent>
+  </div>
+);
+
+export const ImageBadges = () => (
+  <div>
+    <StyledBadgesComponent>
+      <Badges
+        type="small"
+        variant="image"
+        colorsEffect="primary"
+        img="https://i.pravatar.cc/62"
+      />
+      <Badges
+        type="medium"
+        variant="image"
+        colorsEffect="warning"
+        img="https://i.pravatar.cc/61"
+      />
+      <Badges
+        type="large"
+        variant="image"
+        colorsEffect="success"
+        img="https://i.pravatar.cc/60"
+      />
+    </StyledBadgesComponent>
+  </div>
+);

--- a/src/Images/Images.Styled.js
+++ b/src/Images/Images.Styled.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { AvatarContainer } from '../Avatar/Avatar.Styled';
+import Images from './Images'; // Assuming Images is the correct component to use
+
+export default {
+  title: 'Images',
+  component: Images,
+};
+
+export const CircularImages = () => (
+  <div>
+    <AvatarContainer>
+      <Images shape="circle" img="https://i.pravatar.cc/40" />
+      <Images shape="circle" img="https://i.pravatar.cc/41" />
+    </AvatarContainer>
+  </div>
+);
+
+export const SquareImages = () => (
+  <div>
+    <AvatarContainer>
+      <Images shape="square" img="https://i.pravatar.cc/45" />
+      <Images shape="square" img="https://i.pravatar.cc/44" />
+    </AvatarContainer>
+  </div>
+);
+
+export const ResponsiveImages = () => (
+  <div>
+    <AvatarContainer>
+      <Images shape="response" img="https://i.pravatar.cc/" />
+    </AvatarContainer>
+  </div>
+);

--- a/src/Images/Images.Styled.js
+++ b/src/Images/Images.Styled.js
@@ -1,34 +1,59 @@
-import React from 'react';
-import { AvatarContainer } from '../Avatar/Avatar.Styled';
-import Images from './Images'; // Assuming Images is the correct component to use
+import styled, { css } from 'styled-components';
 
-export default {
-  title: 'Images',
-  component: Images,
+const sizes = {
+  circle: { widths: '150px', heights: '150px' },
+  square: { widths: '150px', heights: '150px' },
+  response: { widths: '100%', heights: '100%' },
 };
 
-export const CircularImages = () => (
-  <div>
-    <AvatarContainer>
-      <Images shape="circle" img="https://i.pravatar.cc/40" />
-      <Images shape="circle" img="https://i.pravatar.cc/41" />
-    </AvatarContainer>
-  </div>
-);
+export const StyledImagesComponent = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  justify-content: center;
+  align-items: center;
+  height: auto;
 
-export const SquareImages = () => (
-  <div>
-    <AvatarContainer>
-      <Images shape="square" img="https://i.pravatar.cc/45" />
-      <Images shape="square" img="https://i.pravatar.cc/44" />
-    </AvatarContainer>
-  </div>
-);
+  img {
+    margin: auto;
+    ${({ shape }) =>
+      shape &&
+      css`
+        width: ${sizes[shape].widths || 'auto'};
+        height: ${sizes[shape].heights || 'auto'};
+      `};
 
-export const ResponsiveImages = () => (
-  <div>
-    <AvatarContainer>
-      <Images shape="response" img="https://i.pravatar.cc/" />
-    </AvatarContainer>
-  </div>
-);
+    ${({ shape }) =>
+      shape === 'square' &&
+      css`
+        object-fit: cover;
+        overflow-clip-margin: content-box;
+        overflow-x: clip;
+        overflow-y: clip;
+      `};
+
+    ${({ shape }) =>
+      shape === 'circle' &&
+      css`
+        border-radius: 50%;
+        overflow: hidden;
+        margin: 0 5px;
+      `};
+
+    ${({ shape }) =>
+      shape === 'response' &&
+      css`
+        object-fit: cover;
+        width: 100%;
+        height: auto;
+
+        @media (min-width: 769px) {
+          width: 800px;
+          height: 480px;
+        }
+
+        padding: 10px;
+        margin: 10px;
+      `};
+  }
+`;

--- a/src/Images/Images.Styled.js
+++ b/src/Images/Images.Styled.js
@@ -7,8 +7,6 @@ const sizes = {
 };
 
 export const StyledImagesComponent = styled.div`
-  display: flex;
-  flex-direction: row;
   gap: 1rem;
   justify-content: center;
   align-items: center;
@@ -46,14 +44,13 @@ export const StyledImagesComponent = styled.div`
         object-fit: cover;
         width: 100%;
         height: auto;
-
-        @media (min-width: 769px) {
-          width: 800px;
-          height: 480px;
-        }
-
         padding: 10px;
         margin: 10px;
+
+        @media (max-width: 769px) {
+          width: 100%;
+          height: auto;
+        }
       `};
   }
 `;

--- a/src/Images/Images.js
+++ b/src/Images/Images.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { StyledImagesComponent } from './Images.Styled';
+
+const Images = ({ shape, img }) => {
+  return (
+    <StyledImagesComponent shape={shape}>
+      <img src={img} alt="Images" />
+    </StyledImagesComponent>
+  );
+};
+
+export default Images;

--- a/src/Images/Images.stories.js
+++ b/src/Images/Images.stories.js
@@ -1,0 +1,59 @@
+import styled, { css } from 'styled-components';
+
+const sizes = {
+  circle: { widths: '150px', heights: '150px' },
+  square: { widths: '150px', heights: '150px' },
+  response: { widths: '100%', heights: '100%' },
+};
+
+export const StyledImagesComponent = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  justify-content: center;
+  align-items: center;
+  height: auto;
+
+  img {
+    margin: auto;
+    ${({ shape }) =>
+      shape &&
+      css`
+        width: ${sizes[shape].widths || 'auto'};
+        height: ${sizes[shape].heights || 'auto'};
+      `};
+
+    ${({ shape }) =>
+      shape === 'square' &&
+      css`
+        object-fit: cover;
+        overflow-clip-margin: content-box;
+        overflow-x: clip;
+        overflow-y: clip;
+      `};
+
+    ${({ shape }) =>
+      shape === 'circle' &&
+      css`
+        border-radius: 50%;
+        overflow: hidden;
+        margin: 0 5px;
+      `};
+
+    ${({ shape }) =>
+      shape === 'response' &&
+      css`
+        object-fit: cover;
+        width: 100%;
+        height: auto;
+
+        @media (min-width: 769px) {
+          width: 800px;
+          height: 480px;
+        }
+
+        padding: 10px;
+        margin: 10px;
+      `};
+  }
+`;

--- a/src/Images/Images.stories.js
+++ b/src/Images/Images.stories.js
@@ -1,59 +1,34 @@
-import styled, { css } from 'styled-components';
+import React from 'react';
+import { AvatarContainer } from '../Avatar/Avatar.Styled';
+import Images from './Images';
 
-const sizes = {
-  circle: { widths: '150px', heights: '150px' },
-  square: { widths: '150px', heights: '150px' },
-  response: { widths: '100%', heights: '100%' },
+export default {
+  title: 'Images',
+  component: Images,
 };
 
-export const StyledImagesComponent = styled.div`
-  display: flex;
-  flex-direction: row;
-  gap: 1rem;
-  justify-content: center;
-  align-items: center;
-  height: auto;
+export const CircularImages = () => (
+  <div>
+    <AvatarContainer>
+      <Images shape="circle" img="https://i.pravatar.cc/40" />
+      <Images shape="circle" img="https://i.pravatar.cc/41" />
+    </AvatarContainer>
+  </div>
+);
 
-  img {
-    margin: auto;
-    ${({ shape }) =>
-      shape &&
-      css`
-        width: ${sizes[shape].widths || 'auto'};
-        height: ${sizes[shape].heights || 'auto'};
-      `};
+export const SquareImages = () => (
+  <div>
+    <AvatarContainer>
+      <Images shape="square" img="https://i.pravatar.cc/45" />
+      <Images shape="square" img="https://i.pravatar.cc/44" />
+    </AvatarContainer>
+  </div>
+);
 
-    ${({ shape }) =>
-      shape === 'square' &&
-      css`
-        object-fit: cover;
-        overflow-clip-margin: content-box;
-        overflow-x: clip;
-        overflow-y: clip;
-      `};
-
-    ${({ shape }) =>
-      shape === 'circle' &&
-      css`
-        border-radius: 50%;
-        overflow: hidden;
-        margin: 0 5px;
-      `};
-
-    ${({ shape }) =>
-      shape === 'response' &&
-      css`
-        object-fit: cover;
-        width: 100%;
-        height: auto;
-
-        @media (min-width: 769px) {
-          width: 800px;
-          height: 480px;
-        }
-
-        padding: 10px;
-        margin: 10px;
-      `};
-  }
-`;
+export const ResponsiveImages = () => (
+  <div>
+    <AvatarContainer>
+      <Images shape="response" img="https://i.pravatar.cc/" />
+    </AvatarContainer>
+  </div>
+);


### PR DESCRIPTION
Add three different kind of images

1) Square Images
<img width="1136" alt="Screenshot 2023-12-27 at 10 01 31 AM" src="https://github.com/aeshapatel025/Strive_UI/assets/152843736/91f3f446-903a-4975-a878-f50cff73254b">

2) Circle Images
<img width="1040" alt="Screenshot 2023-12-27 at 10 01 21 AM" src="https://github.com/aeshapatel025/Strive_UI/assets/152843736/4b2b1472-f0e4-481d-9827-786f7b0cab2e">

3) Responsive Images
<img width="1277" alt="Screenshot 2023-12-27 at 10 01 40 AM" src="https://github.com/aeshapatel025/Strive_UI/assets/152843736/509ec6dc-4176-4ab8-8f2c-b40c4c8e63d9">

- [x] Checking the code is duplicate or not?
- [x]  Is these code has bug
- [ ]  Is code is check by shubhum sir or ankit sir?
- [ ]  Are you going to merge this or not?